### PR TITLE
Mppi lite

### DIFF
--- a/Control_Toolkit_ASF/Controllers/MPPILite/mppi_lite_planner.py
+++ b/Control_Toolkit_ASF/Controllers/MPPILite/mppi_lite_planner.py
@@ -1,11 +1,15 @@
 from utilities.waypoint_utils import *
 from utilities.render_utilities import RenderUtils
 from Control_Toolkit_ASF.Controllers import template_planner
-from f110_sim.envs.dynamic_model_pacejka_jit import *
+from sim.f110_sim.envs.dynamic_model_pacejka_jit import *
 from utilities.car_files.vehicle_parameters import VehicleParameters
 import time
 from scipy.special import softmax
 import os
+import matplotlib.pyplot as plt
+import numpy as np
+
+from numba import njit, prange
 os.environ["NUMBA_NUM_THREADS"] = '8'
 
 
@@ -40,21 +44,25 @@ class MPPILitePlanner(template_planner):
         
         
         # Precompute variables
-        self.batch_size = 2001
+        self.batch_size = 1024
         self.horizon = 50    
         self.last_Q_sq = np.zeros((self.horizon, 2), dtype=np.float32)
         self.car_params_array = VehicleParameters().to_np_array()
 
-        s_batch = np.zeros(( self.batch_size, 7), dtype=np.float32)
+        s_batch = np.zeros(( self.batch_size, 10), dtype=np.float32)
         Q_batch_sequence = np.random.rand(self.horizon,  self.batch_size, 2).astype(np.float32)
         total_cost_batch = np.random.rand(self.batch_size).astype(np.float32)
+        
+        
+        print("JIT compilation started", Q_batch_sequence.shape)
 
         # Call JIT functions once to force compilation
-        _ = car_step_parallel(s_batch, Q_batch_sequence[0], self.car_params_array, 0.01)
+        _ = car_step_parallel(s_batch, Q_batch_sequence[0], self.car_params_array, 0.02)
         _ = batch_sequence(Q_batch_sequence, s_batch, self.car_params_array)
-        # _ = cost_function_batch_sequence(Q_batch_sequence, Q_batch_sequence, self.waypoint_utils.next_waypoints)
+        _ = car_batch_sequence(s_batch,  Q_batch_sequence, self.car_params_array)
+        _ = cost_function_batch_sequence(Q_batch_sequence, Q_batch_sequence, np.zeros((30, 8)))
         _ = exponential_weighting(Q_batch_sequence, total_cost_batch)
-        _ = compute_waypoint_distance(np.zeros(7), np.zeros((30, 8)))
+        _ = compute_waypoint_distance(np.zeros(10), np.zeros((30, 8)))
         print("JIT compilation completed")
         
 
@@ -84,7 +92,7 @@ class MPPILitePlanner(template_planner):
         self.control_index += 1
         return self.angular_control, self.translational_control
 
-@njit(fastmath=True, parallel=True)
+@njit(fastmath=True)
 def process_observation_jit(s, last_Q_sq, batch_size, horizon, car_params_array, next_waypoints):
     # Initialize s_batch manually
     s_batch = np.zeros((batch_size, s.shape[0]), dtype=np.float32)
@@ -92,11 +100,11 @@ def process_observation_jit(s, last_Q_sq, batch_size, horizon, car_params_array,
         s_batch[i] = s
 
     # Manually shift last_Q_sq instead of using np.roll()
-    print(f"Before shift: last_Q_sq.shape = {last_Q_sq.shape}")
+    # print(f"Before shift: last_Q_sq.shape = {last_Q_sq.shape}")
 
     last_Q_sq[:-1] = last_Q_sq[1:]  # Shift all rows forward
     last_Q_sq[-1] = np.random.rand(2).astype(np.float32)  # Update last row
-    print(f"After shift: last_Q_sq.shape = {last_Q_sq.shape}")
+    # print(f"After shift: last_Q_sq.shape = {last_Q_sq.shape}")
 
 
     # Expand last_Q_sq to batch size using a loop (Numba-compatible)
@@ -107,11 +115,14 @@ def process_observation_jit(s, last_Q_sq, batch_size, horizon, car_params_array,
 
     # Perturb Qs by adding random noise
     random_perturbation = np.zeros((horizon, batch_size, 2), dtype=np.float32)
-    random_perturbation[:, :, 0] = np.random.uniform(-0.2, 0.2, size=(horizon, batch_size))
-    random_perturbation[:, :, 1] = np.random.uniform(-1, 1, size=(horizon, batch_size))
-
+    # random_perturbation[:, :, 0] = np.random.uniform(-0.2, 0.2, size=(horizon, batch_size))
+    # random_perturbation[:, :, 1] = np.random.uniform(-1., 1., size=(horizon, batch_size))
     
+    random_perturbation[:, :, 0] = np.random.normal(0, 0.3, size=(horizon, batch_size))
+    random_perturbation[:, :, 1] = np.random.normal(0.1, 1.0, size=(horizon, batch_size))
     Q_batch_sequence += random_perturbation
+    
+
 
     # Clip control values (steering angle -0.4 - 0.4 and throttle -10, 10)
     # Define control limits
@@ -124,13 +135,45 @@ def process_observation_jit(s, last_Q_sq, batch_size, horizon, car_params_array,
 
         
     # Run batch rollout
-    state_batch_rollout = batch_sequence(Q_batch_sequence, s_batch, car_params_array)
-
-    # Compute total cost
+    # state_batch_rollout = batch_sequence(Q_batch_sequence, s_batch, car_params_array)
+    state_batch_rollout = car_batch_sequence(s_batch, Q_batch_sequence, car_params_array)
     waypoints = next_waypoints
-    total_cost_batch = cost_function_batch_sequence(state_batch_rollout, Q_batch_sequence, waypoints)
-    # Compute optimal Q sequence
+    cost_batch_sequence = cost_function_batch_sequence(state_batch_rollout, Q_batch_sequence, waypoints) # 50, 1024
+    total_cost_batch = np.sum(cost_batch_sequence, axis=0)  # Sum costs over the horizon for each batch
+    
     Q_sequence = exponential_weighting(Q_batch_sequence, total_cost_batch)
+    optimal_trajectory = cat_steps_sequential(s, Q_sequence, car_params_array, 0.02, horizon)
+    
+    if False:
+        plt.clf()
+        for i in range(20):
+            plt.scatter(
+                state_batch_rollout[:, i, 6],  # X position
+                state_batch_rollout[:, i, 7],  # Y position
+                s=5,
+                c=np.full(state_batch_rollout.shape[0], total_cost_batch[i]),  # color by cost
+                cmap='viridis',
+                vmin=np.min(total_cost_batch),
+                vmax=np.max(total_cost_batch),
+                label=f'Batch {i}' if i == 0 else None
+            )
+        plt.scatter(
+            optimal_trajectory[:, 6],  # X position
+            optimal_trajectory[:, 7],  # Y position
+            s=5,
+            c='red',  # color for the optimal trajectory
+            label='Optimal Trajectory'
+        )
+
+        plt.colorbar(label='Total Cost')
+        plt.title("Car positions colored by cost")
+        plt.xlabel("X position")
+        plt.ylabel("Y position")
+        plt.axis('equal')
+        plt.savefig("car_positions_colored_by_cost.png")
+            
+    # Compute total cost
+    # Compute optimal Q sequence
 
     # Extract the first control decision
     next_control = Q_sequence[0]
@@ -145,52 +188,58 @@ def cost_function(state, control, waypoints):
     """
     Computes cost based on speed, control effort, and distance to the next waypoint.
     """
-    speed_cost = state[3] * -0.08  # Penalize low speed
+       
+    
     angular_cost = abs(control[0]) * 0.0  # Penalize sharp steering
 
     # Compute waypoint distance cost
-    waypoint_dist_sq = compute_waypoint_distance(state, waypoints)
-    waypoint_cost = waypoint_dist_sq * 0.1  # Scale weight for balancing
+    waypoint_dist_sq, min_dist_wp_idx = compute_waypoint_distance(state, waypoints)
+    waypoint_cost = waypoint_dist_sq * 1.0  # Scale weight for balancing
+
+
+    target_speed = waypoints[min_dist_wp_idx][5]  # Target speed in m/s
+    speed_cost = 0.1 * (state[LINEAR_VEL_X_IDX] - target_speed) ** 2 
 
     total_cost = speed_cost + angular_cost + waypoint_cost
     return total_cost
 
 
-@njit(fastmath=True, parallel=True)
-def cost_function_batch(state_batch, control_batch, waypoints):
+@njit(fastmath=True)
+def cost_function_sequence(state_sequence, control_sequence, waypoints):
     """
     Computes cost for a batch of states and controls.
     """
-    batch_size = state_batch.shape[0]
-    cost_batch = np.zeros(batch_size, dtype=np.float32)
+    sequence_length = state_sequence.shape[0]
+    cost_sequence = np.zeros(sequence_length, dtype=np.float32)
+    
+    for i in prange(sequence_length):  # Parallel execution
+        cost_sequence[i] = cost_function(state_sequence[i], control_sequence[i], waypoints)
 
-    for i in prange(batch_size):  # Parallel execution
-        cost_batch[i] = cost_function(state_batch[i], control_batch[i], waypoints)
-
-    return cost_batch
+    return cost_sequence
 
 
-@njit(fastmath=True,)
+@njit(fastmath=True, parallel=True)
 def cost_function_batch_sequence(state_batch_rollout, Q_batch_sequence, waypoints):
     """
     Computes total cost for an entire batch sequence using waypoint distances.
     """
-    horizon, batch_size = state_batch_rollout.shape[:2]
-    total_cost_batch = np.zeros(batch_size, dtype=np.float32)
+    horizon, batch_size, _ = state_batch_rollout.shape
+    
+    cost_sequence_batch = np.zeros((horizon, batch_size), dtype=np.float32)
 
-    for index in prange(horizon):  
-        total_cost_batch += cost_function_batch(state_batch_rollout[index], Q_batch_sequence[index], waypoints)
+    for index in prange(batch_size):  
+        cost_sequence_batch[:, index] = cost_function_sequence(state_batch_rollout[:, index], Q_batch_sequence[:, index], waypoints)
 
-    return total_cost_batch
+    return cost_sequence_batch
 
 
 @njit(fastmath=True, parallel=True)
-def exponential_weighting(Q_batch_sequence, total_cost_batch, temperature=0.5):
+def exponential_weighting(Q_batch_sequence, total_cost_batch, temperature=0.1):
     # Softmax manually implemented for Numba compatibility
     max_cost = np.max(-total_cost_batch)  # Subtract max for numerical stability
     exp_weights = np.exp((-total_cost_batch - max_cost) / temperature)
     weights = exp_weights / np.sum(exp_weights)
-
+    
     # Reshape weights for broadcasting
     Q_batch_sequence_weighted = Q_batch_sequence * weights.reshape(1, -1, 1)
 
@@ -202,20 +251,33 @@ def exponential_weighting(Q_batch_sequence, total_cost_batch, temperature=0.5):
 @njit(fastmath=True, parallel=True)
 def batch_sequence(Q_batch_sequence, s_batch, car_params):
     horizon, batch_size, _ = Q_batch_sequence.shape
-    state_batch_sequence = np.zeros((horizon, batch_size, 7), dtype=np.float32)
+    state_batch_sequence = np.zeros((horizon, batch_size, 10), dtype=np.float32)
 
-    dt = 0.01  
+    dt = 0.02  
 
     for i in range(horizon):  
         # Process all batches in parallel
-        state_batch_sequence[i] = car_step_parallel(s_batch, Q_batch_sequence[i], car_params, dt)
+        
+        s_batch[:, :] = car_step_parallel(s_batch, Q_batch_sequence[i], car_params, dt)
+        state_batch_sequence[i] = s_batch
 
-        # Instead of modifying `s_batch` in-place, store the last state explicitly
-        if i < horizon - 1:
-            s_batch[:] = state_batch_sequence[i]
+        # Optionally update s_batch here if needed
+        # but it's usually not needed
 
     return state_batch_sequence
 
+
+@njit(fastmath=True, parallel=True, nopython=True)
+def car_batch_sequence(s_batch, Q_batch_sequence, car_params): 
+    horizon, batch_size, _ = Q_batch_sequence.shape
+
+    state_batch_trajectory = np.zeros((horizon, batch_size, 10), dtype=np.float32)
+    for i in prange(batch_size - 1):
+        state_trajectory = cat_steps_sequential(s_batch[i],  Q_batch_sequence[:, i], car_params, 0.02, horizon)
+        state_batch_trajectory[:, i] = state_trajectory
+
+    
+    return state_batch_trajectory
 
 
 @njit(fastmath=True)
@@ -225,12 +287,12 @@ def compute_waypoint_distance(state, waypoints):
     and returns the minimum distance found.
     """
     min_dist_sq = 1e6  # Large initial value
-    car_x, car_y = state[0], state[1]  # Extract car position
-
+    car_x, car_y = state[POSE_X_IDX], state[POSE_Y_IDX]  # Extract car position
+    min_dist_wp_idx = -1
     for i in range(waypoints.shape[0]):  # Loop through waypoints
         wp_x, wp_y = waypoints[i, 1], waypoints[i, 2]
         dist_sq = (car_x - wp_x) ** 2 + (car_y - wp_y) ** 2  # Squared Euclidean distance
         if dist_sq < min_dist_sq:
             min_dist_sq = dist_sq  # Update minimum distance
-
-    return min_dist_sq  # Return squared distance to avoid sqrt computation
+            min_dist_wp_idx = i
+    return min_dist_sq, min_dist_wp_idx  # Return squared distance to avoid sqrt computation

--- a/run/ci_test.py
+++ b/run/ci_test.py
@@ -54,7 +54,24 @@ if __name__ == "__main__":
     Settings.GLOBAL_WAYPOINT_VEL_FACTOR = 1.0 
     
     Settings.CONTROL_DELAY = 0.08
-    Settings.EXECUTE_NTH_STEP_OF_CONTROL_SEQUENCE = 4
+
+    importlib.reload(run_simulation)    
+    time.sleep(1)
+
+    simulation = RacingSimulation()
+    simulation.run_experiments()
+
+    # Assert at least one lap was completed
+    laptimes = simulation.drivers[0].laptimes
+    assert len(laptimes) > 0, "No lap times recorded"
+
+
+    time.sleep(1)
+     # Test: Run the simulation with the PP controller on the RCA2 map (with delay)
+    Settings.CONTROLLER = 'mppi-lite'
+    Settings.GLOBAL_WAYPOINT_VEL_FACTOR = 0.9 
+    
+    Settings.CONTROL_DELAY = 0.08
 
     importlib.reload(run_simulation)    
     time.sleep(1)
@@ -63,4 +80,7 @@ if __name__ == "__main__":
     simulation = RacingSimulation()
     simulation.run_experiments()
 
+    # Assert at least one lap was completed
+    laptimes = simulation.drivers[0].laptimes
+    assert len(laptimes) > 0, "No lap times recorded"
 

--- a/sim/f110_sim/envs/base_classes.py
+++ b/sim/f110_sim/envs/base_classes.py
@@ -288,7 +288,6 @@ class RaceCar(object):
 
         # if in collision stop vehicle
         if in_collision:
-            self.state[StateIndices.v_x:] = 0.0
             self.accel = 0.0
             self.steer_angle_vel = 0.0
 

--- a/sim/f110_sim/envs/dynamic_model_pacejka_jit.py
+++ b/sim/f110_sim/envs/dynamic_model_pacejka_jit.py
@@ -128,6 +128,31 @@ def car_dynamics_pacejka_jit(s, Q, car_params, t_step):
 
 
 
+@njit(fastmath=True)
+def cat_steps_sequential(s, Q_sequence, car_params, t_step, num_steps):
+    """
+    Runs car_step for single car sequentially.
+
+    Inputs:
+    - states: (10) array of states
+    - Qs: (2, H) Sequence of H Controlls applied to the car
+    - car_params: (fixed-size) array of car parameters
+    - t_step: time step
+    - num_steps: number of steps to run
+
+    Output:
+    - state_trajectory: Trajetory of states during apng aplying the H controlls
+    """
+    
+    state_trajectory = np.zeros((num_steps, 10), dtype=np.float32)
+    
+    for i in range(num_steps):
+        s = car_dynamics_pacejka_jit(s, Q_sequence[i], car_params, t_step)
+        state_trajectory[i] = s
+    return state_trajectory
+
+        
+        
 
 @njit(parallel=True, fastmath=True)
 def car_step_parallel(states, Qs, car_params, t_step):

--- a/sim/f110_sim/envs/dynamic_model_pacejka_jit.py
+++ b/sim/f110_sim/envs/dynamic_model_pacejka_jit.py
@@ -66,7 +66,18 @@ def car_dynamics_pacejka_jit(s, Q, car_params, t_step):
   
     v_x_dot = translational_control
         
-    v_x_dot = max(min(v_x_dot, a_max), a_min)  # Apply acceleration constraints
+    # v_x_dot = max(min(v_x_dot, a_max), a_min)  # Apply acceleration constraints
+    # Limit due to velocity (motor power)
+    if v_x > v_switch:
+        pos_limit = a_max * v_switch / v_x
+    else:
+        pos_limit = a_max
+    v_x_dot = min(v_x_dot, pos_limit)
+
+    # Limit due to tire friction
+    max_a_friction = mu * g_
+    v_x_dot = min(max(v_x_dot, -max_a_friction), max_a_friction)
+
 
     # Euler integration with optimized calculations
     for _ in range(1):  # Keep intermediate_steps = 1 for simplicity
@@ -84,7 +95,7 @@ def car_dynamics_pacejka_jit(s, Q, car_params, t_step):
         # Compute lateral forces using Pacejka's formula
         F_yf = mu * F_zf * D_f * np.sin(C_f * np.arctan(B_f * alpha_f - E_f * (B_f * alpha_f - np.arctan(B_f * alpha_f))))
         F_yr = mu * F_zr * D_r * np.sin(C_r * np.arctan(B_r * alpha_r - E_r * (B_r * alpha_r - np.arctan(B_r * alpha_r))))
-
+                
         # Compute state derivatives
         d_s_x = v_x * np.cos(psi) - v_y * np.sin(psi)
         d_s_y = v_x * np.sin(psi) + v_y * np.cos(psi)

--- a/sim/f110_sim/envs/dynamic_model_pacejka_jit.py
+++ b/sim/f110_sim/envs/dynamic_model_pacejka_jit.py
@@ -129,7 +129,7 @@ def car_dynamics_pacejka_jit(s, Q, car_params, t_step):
 
 
 @njit(fastmath=True)
-def cat_steps_sequential(s, Q_sequence, car_params, t_step, num_steps):
+def car_steps_sequential(s, Q_sequence, car_params, t_step, num_steps):
     """
     Runs car_step for single car sequentially.
 

--- a/utilities/Settings.py
+++ b/utilities/Settings.py
@@ -16,7 +16,7 @@ class Settings():
     AVERAGE_WINDOW = 200  # Window for avg filter [friction]
 
     # Controller Settings
-    CONTROLLER = 'mpc' # Options: 'manual' (requires connected joystick) ,'mpc', 'ftg' (follow the gap), neural (neural network),  'pp' (pure pursuit), 'stanley' (stanley controller)
+    CONTROLLER = 'mppi-lite' # Options: 'manual' (requires connected joystick) ,'mpc', 'ftg' (follow the gap), neural (neural network),  'pp' (pure pursuit), 'stanley' (stanley controller)
 
     TIMESTEP_CONTROL = 0.02    # Multiple of 0.01; how often to recalculate control input
     TIMESTEP_SIM = 0.01       # Dont touch.
@@ -31,7 +31,7 @@ class Settings():
     STARTING_POSITION = [[3.62, 6.26, 0.378]] # Starting position [x, y, yaw] in case of START_FROM_RANDOM_POSITION = False
     
     REVERSE_DIRECTION = False # Drive reverse waypoints
-    GLOBAL_WAYPOINT_VEL_FACTOR = 1.0
+    GLOBAL_WAYPOINT_VEL_FACTOR = 0.9
     GLOBAL_SPEED_LIMIT = 15.0
     APPLY_SPEED_SCALING_FROM_CSV = False # Speed scaling from speed_scaling.yaml are multiplied with GLOBAL_WAYPOINT_VEL_FACTOR
 
@@ -74,14 +74,14 @@ class Settings():
 
     # Experiment Settings
     NUMBER_OF_EXPERIMENTS = 1  # How many times to run the car racing experiment
-    EXPERIMENT_LENGTH = 3000  # in timesteps, only valid if DISABLE_AUTOMATIC_TIMEOUT is True.
+    EXPERIMENT_LENGTH = 10000  # in timesteps, only valid if DISABLE_AUTOMATIC_TIMEOUT is True.
     STOP_TIMER_AFTER_N_LAPS = 2                 # Timer stops after N laps for competition 
     DISABLE_AUTOMATIC_TERMINATION = False
     DISABLE_AUTOMATIC_TIMEOUT = True
 
 
     ## Noise ##
-    CONTROL_DELAY = 0.08 # Delay between control calculated and control applied to the car, multiple of 0.01 [s]
+    CONTROL_DELAY = 0.00 # Delay between control calculated and control applied to the car, multiple of 0.01 [s]
     # Delay on physical car is about 0.06s (Baseline right now is 0.1s)
     
     NOISE_LEVEL_CAR_STATE = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

--- a/utilities/Settings.py
+++ b/utilities/Settings.py
@@ -81,7 +81,7 @@ class Settings():
 
 
     ## Noise ##
-    CONTROL_DELAY = 0.00 # Delay between control calculated and control applied to the car, multiple of 0.01 [s]
+    CONTROL_DELAY = 0.08 # Delay between control calculated and control applied to the car, multiple of 0.01 [s]
     # Delay on physical car is about 0.06s (Baseline right now is 0.1s)
     
     NOISE_LEVEL_CAR_STATE = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

--- a/utilities/Settings.py
+++ b/utilities/Settings.py
@@ -16,7 +16,7 @@ class Settings():
     AVERAGE_WINDOW = 200  # Window for avg filter [friction]
 
     # Controller Settings
-    CONTROLLER = 'mppi-lite' # Options: 'manual' (requires connected joystick) ,'mpc', 'ftg' (follow the gap), neural (neural network),  'pp' (pure pursuit), 'stanley' (stanley controller)
+    CONTROLLER = 'mppi-lite' # Options: 'manual','mpc','ftg',neural,'pp','stanley', 'mppi-lite'
 
     TIMESTEP_CONTROL = 0.02    # Multiple of 0.01; how often to recalculate control input
     TIMESTEP_SIM = 0.01       # Dont touch.


### PR DESCRIPTION
A very **simple lightweight vanilla MPPI** controller for the car. 

Just set the controller name in [Settings.py](https://github.com/F1Tenth-INI/f1tenth_development_gym/blob/main/utilities/Settings.py)

```python
CONTROLLER = 'mppi-lite'
```


It runs the car model and the cost function inside _njit_ compiled python blocks.

Everything is as minimal as possible. This code can be useful for fast evaluation of new ideas/methods, before finally integrating them into the SI toolkit when they are successful.

Runs realtime on my laptop with 1k rollouts, horizon of 75 steps
Can do 18.6 seconds laps on RCA1.